### PR TITLE
refactor: Dispense with the Promise detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,8 +209,7 @@ class Hystrix {
     }
     curBucket.shortCircuits++
     if (fallback) {
-      const result = fallback()
-      return Object.prototype.toString.call(result).slice(8, -1) === 'Promise' ? result : Promise.resolve(result)
+      return Promise.resolve(fallback())
     }
     throw new Error('Bad Request!')
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "ava": "^0.24.0",
+    "is-promise": "^2.1.0",
     "nyc": "^11.3.0",
     "standard": "^10.0.3"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 const Hystrix = require('../')
 const _ = require('lodash')
+const isPromise = require('is-promise')
 
 const OPEN = 0
 const HALF_OPEN = 1
@@ -69,7 +70,9 @@ test('With a broken service', async t => {
   }
 
   const fallback = () => 1
-  const count = await hystrix.run(timeoutCommand, fallback)
+  const runResult = hystrix.run(timeoutCommand, fallback)
+  t.true(isPromise(runResult), 'fallback result should be a Promise')
+  const count = await runResult
   t.is(count, 1, 'should run the fallback and return its result if one is provided')
 
   // 一段时间后切换到 HALF_OPEN


### PR DESCRIPTION
We don't have to worry about the result type since `Promise.resolve(Promise.resolve('result'))` is a valid Promise result.